### PR TITLE
fix(matroska): keep pixel dimensions with display size

### DIFF
--- a/internal/mediainfo/golden_test.go
+++ b/internal/mediainfo/golden_test.go
@@ -82,7 +82,10 @@ func TestGoldenOutputs(t *testing.T) {
 }
 
 func normalizeText(s string) string {
-	return strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, `samples\\`, "samples/")
+	s = strings.ReplaceAll(s, `samples\`, "samples/")
+	return s
 }
 
 var (

--- a/internal/mediainfo/matroska.go
+++ b/internal/mediainfo/matroska.go
@@ -1609,24 +1609,6 @@ func parseMatroskaTrackEntry(buf []byte, segmentDuration float64, durationPrec i
 		if videoInfo.codedHeight > 0 {
 			storedHeight = videoInfo.codedHeight
 		}
-		displayWidth := videoInfo.displayWidth
-		displayHeight := videoInfo.displayHeight
-		if displayWidth == 0 && sampledWidth > 0 {
-			crop := videoInfo.cropLeft + videoInfo.cropRight
-			if crop > 0 && crop < sampledWidth {
-				displayWidth = sampledWidth - crop
-			} else {
-				displayWidth = sampledWidth
-			}
-		}
-		if displayHeight == 0 && sampledHeight > 0 {
-			crop := videoInfo.cropTop + videoInfo.cropBottom
-			if crop > 0 && crop < sampledHeight {
-				displayHeight = sampledHeight - crop
-			} else {
-				displayHeight = sampledHeight
-			}
-		}
 		if storedWidth > 0 && sampledWidth > 0 && storedWidth != sampledWidth {
 			jsonExtras["Stored_Width"] = strconv.FormatUint(storedWidth, 10)
 		}

--- a/internal/mediainfo/matroska.go
+++ b/internal/mediainfo/matroska.go
@@ -1389,8 +1389,16 @@ func parseMatroskaTrackEntry(buf []byte, segmentDuration float64, durationPrec i
 	}
 	if kind == StreamVideo {
 		bitRateNominal := spsInfo.HasBitRateCBR && spsInfo.BitRateCBR
-		storedWidth := videoInfo.pixelWidth
-		storedHeight := videoInfo.pixelHeight
+		sampledWidth := videoInfo.pixelWidth
+		sampledHeight := videoInfo.pixelHeight
+		if spsInfo.Width > 0 {
+			sampledWidth = spsInfo.Width
+		}
+		if spsInfo.Height > 0 {
+			sampledHeight = spsInfo.Height
+		}
+		storedWidth := sampledWidth
+		storedHeight := sampledHeight
 		if videoInfo.codedWidth > 0 {
 			storedWidth = videoInfo.codedWidth
 		}
@@ -1399,24 +1407,14 @@ func parseMatroskaTrackEntry(buf []byte, segmentDuration float64, durationPrec i
 		}
 		displayWidth := videoInfo.displayWidth
 		displayHeight := videoInfo.displayHeight
-		if videoInfo.displayUnit != 0 {
-			displayWidth = 0
-			displayHeight = 0
+		if sampledWidth > 0 {
+			fields = append(fields, Field{Name: "Width", Value: formatPixels(sampledWidth)})
 		}
-		outWidth := storedWidth
-		outHeight := storedHeight
-		if displayWidth > 0 && displayHeight > 0 {
-			outWidth = displayWidth
-			outHeight = displayHeight
+		if sampledHeight > 0 {
+			fields = append(fields, Field{Name: "Height", Value: formatPixels(sampledHeight)})
 		}
-		if outWidth > 0 {
-			fields = append(fields, Field{Name: "Width", Value: formatPixels(outWidth)})
-		}
-		if outHeight > 0 {
-			fields = append(fields, Field{Name: "Height", Value: formatPixels(outHeight)})
-		}
-		aspectW := storedWidth
-		aspectH := storedHeight
+		aspectW := sampledWidth
+		aspectH := sampledHeight
 		if displayWidth > 0 && displayHeight > 0 {
 			aspectW = displayWidth
 			aspectH = displayHeight
@@ -1595,8 +1593,16 @@ func parseMatroskaTrackEntry(buf []byte, segmentDuration float64, durationPrec i
 		}
 	}
 	if kind == StreamVideo {
-		storedWidth := videoInfo.pixelWidth
-		storedHeight := videoInfo.pixelHeight
+		sampledWidth := videoInfo.pixelWidth
+		sampledHeight := videoInfo.pixelHeight
+		if spsInfo.Width > 0 {
+			sampledWidth = spsInfo.Width
+		}
+		if spsInfo.Height > 0 {
+			sampledHeight = spsInfo.Height
+		}
+		storedWidth := sampledWidth
+		storedHeight := sampledHeight
 		if videoInfo.codedWidth > 0 {
 			storedWidth = videoInfo.codedWidth
 		}
@@ -1605,31 +1611,31 @@ func parseMatroskaTrackEntry(buf []byte, segmentDuration float64, durationPrec i
 		}
 		displayWidth := videoInfo.displayWidth
 		displayHeight := videoInfo.displayHeight
-		if displayWidth == 0 && storedWidth > 0 {
+		if displayWidth == 0 && sampledWidth > 0 {
 			crop := videoInfo.cropLeft + videoInfo.cropRight
-			if crop > 0 && crop < storedWidth {
-				displayWidth = storedWidth - crop
+			if crop > 0 && crop < sampledWidth {
+				displayWidth = sampledWidth - crop
 			} else {
-				displayWidth = storedWidth
+				displayWidth = sampledWidth
 			}
 		}
-		if displayHeight == 0 && storedHeight > 0 {
+		if displayHeight == 0 && sampledHeight > 0 {
 			crop := videoInfo.cropTop + videoInfo.cropBottom
-			if crop > 0 && crop < storedHeight {
-				displayHeight = storedHeight - crop
+			if crop > 0 && crop < sampledHeight {
+				displayHeight = sampledHeight - crop
 			} else {
-				displayHeight = storedHeight
+				displayHeight = sampledHeight
 			}
 		}
-		if storedWidth > 0 && displayWidth > 0 && storedWidth != displayWidth {
+		if storedWidth > 0 && sampledWidth > 0 && storedWidth != sampledWidth {
 			jsonExtras["Stored_Width"] = strconv.FormatUint(storedWidth, 10)
 		}
-		if storedHeight == displayHeight && displayHeight > 0 && codecID == "V_MPEG4/ISO/AVC" {
-			if displayHeight%16 != 0 {
-				storedHeight = ((displayHeight + 15) / 16) * 16
+		if storedHeight == sampledHeight && sampledHeight > 0 && codecID == "V_MPEG4/ISO/AVC" {
+			if sampledHeight%16 != 0 {
+				storedHeight = ((sampledHeight + 15) / 16) * 16
 			}
 		}
-		if storedHeight > 0 && displayHeight > 0 && storedHeight != displayHeight {
+		if storedHeight > 0 && sampledHeight > 0 && storedHeight != sampledHeight {
 			jsonExtras["Stored_Height"] = strconv.FormatUint(storedHeight, 10)
 		}
 		if spsInfo.HasFixedFrameRate && !spsInfo.FixedFrameRate {

--- a/internal/mediainfo/matroska_test.go
+++ b/internal/mediainfo/matroska_test.go
@@ -180,6 +180,35 @@ func TestParseMatroskaTrackEntryNonHeaderCompression(t *testing.T) {
 	}
 }
 
+func TestParseMatroskaTrackEntryKeepsPixelDimensionsWithDisplaySize(t *testing.T) {
+	videoPayload := make([]byte, 0, 32)
+	videoPayload = append(videoPayload, buildMatroskaElement(mkvIDPixelWidth, encodeMatroskaUint(1920))...)
+	videoPayload = append(videoPayload, buildMatroskaElement(mkvIDPixelHeight, encodeMatroskaUint(1038))...)
+	videoPayload = append(videoPayload, buildMatroskaElement(mkvIDDisplayWidth, encodeMatroskaUint(320))...)
+	videoPayload = append(videoPayload, buildMatroskaElement(mkvIDDisplayHeight, encodeMatroskaUint(173))...)
+	video := buildMatroskaElement(mkvIDTrackVideo, videoPayload)
+	entry := append(
+		buildMatroskaElement(mkvIDTrackType, encodeMatroskaUint(1)),
+		buildMatroskaElement(mkvIDTrackNumber, encodeMatroskaUint(1))...,
+	)
+	entry = append(entry, buildMatroskaElement(mkvIDCodecID, []byte("V_MPEG4/ISO/AVC"))...)
+	entry = append(entry, video...)
+
+	stream, ok := parseMatroskaTrackEntry(entry, 0, 3)
+	if !ok {
+		t.Fatalf("expected parsed stream")
+	}
+	if got := findField(stream.Fields, "Width"); got != "1 920 pixels" {
+		t.Fatalf("Width=%q", got)
+	}
+	if got := findField(stream.Fields, "Height"); got != "1 038 pixels" {
+		t.Fatalf("Height=%q", got)
+	}
+	if got := findField(stream.Fields, "Display aspect ratio"); got != "1.85:1" {
+		t.Fatalf("Display aspect ratio=%q", got)
+	}
+}
+
 func TestParseMatroskaInfoDateUTC(t *testing.T) {
 	base := time.Date(2001, time.January, 1, 0, 0, 0, 0, time.UTC)
 	target := time.Date(2012, time.November, 28, 15, 41, 23, 0, time.UTC)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video dimension extraction to prioritize actual pixel dimensions over display settings when processing media files.
  * Enhanced file path normalization during processing.

* **Tests**
  * Added test coverage to ensure accurate dimension reporting for video tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->