### PR TITLE
[Superseded by #20] fix(matroska): parity quick wins — AC-3 endianness, integer FrameRate_Num/Den, DTS Format

### DIFF
--- a/docs/parity-audit-2026-06-19.md
+++ b/docs/parity-audit-2026-06-19.md
@@ -1,0 +1,175 @@
+# go-mediainfo parity audit — 2026-06-19
+
+**Question asked:** is this rewrite 1:1 with MediaInfo, and where is the original "lacking/ancient"?
+**Bar:** release media only (MKV / MP4 / TS / M2TS-BDAV / DVD-VOB / common audio).
+**Reference:** official `mediainfo --Output=JSON --Language=raw --ParseSpeed=0.5` (MediaInfoLib **v23.04**) vs `go-mediainfo --output=JSON --language=raw`, both run on the same files on `root@media` (Linux x86_64).
+
+---
+
+## TL;DR
+
+The port is **much closer to 1:1 than not**, and it is **dramatically faster and more robust** than the original:
+
+- **0 crashes, 0 timeouts** across 48 real files (incl. 44 GB MKV, BD50 M2TS, 4K HDR/DV).
+- **go is 5–50× faster** than official at ParseSpeed=0.5 (e.g. Oppenheimer 19 GB: go **80 ms** vs official **4 582 ms**; Cape Fear 4K HDR/DV: go **1.5 s** vs official **12.1 s**).
+- **Track detection is essentially perfect** — exact track counts on every file except `.mpls` (unimplemented), one TS caption track, and m4b chapters.
+- After removing one systematic *non-bug* artifact (below): **7/48 byte-perfect, 16 within 2 fields, 22 within 5 fields.**
+- The biggest, most visible single bug: **`General.StreamSize` is 40–50× too large** on a class of MKVs (a stream-size derivation gap), e.g. 11.7 GB reported where official says 248 MB.
+- Modern-codec coverage is where it's genuinely "ancient-adjacent": **no AV1 support at all.**
+
+This is a solid base. The remaining parity gaps cluster into ~16 well-defined items, most small, a few high-leverage.
+
+---
+
+## The one artifact that inflates every diff
+
+On **100% of files**, go emits two fields official (on Linux) does not:
+
+```
++ "File_Created_Date":       "2022-07-25 18:10:53 UTC"
++ "File_Created_Date_Local": "2022-07-25 18:10:53"
+```
+
+MediaInfoLib v23.04 on Linux leaves file *creation* time blank (it historically couldn't read birth-time); go reads it and emits it. This is go being **more complete**, not wrong — but it breaks strict 1:1. It is the reason the known-good TS controls (`Nickelodeon`, `Evermoor`) and all three DVD IFOs score "2" instead of "0". **All numbers below have this artifact removed.**
+
+> **Decision needed:** keep `File_Created_Date` (more correct) or suppress it under a strict-parity mode/flag. Recommend: keep, but gate behind a `--strict-parity`/platform toggle so 1:1 comparisons are clean.
+
+---
+
+## Method
+
+- Built `go-mediainfo` for linux/amd64, ran **both tools next to the files** (no large transfers).
+- Per file: normalize both JSONs (`jq -S 'del(.creatingLibrary)'`), then a Python analyzer that **aligns tracks by @type/StreamOrder/ID** (not array index — verified order matches) and classifies every leaf field as go-missing / go-extra / value-mismatch.
+- Disk-polite: `ionice -c3 nice -n10`, ParseSpeed=0.5, sequential, 240 s timeout guard.
+- Raw artifacts: `/tmp/parity-audit-local/` (JSON pairs, diffs, `analysis.json`, `summary.tsv`).
+
+**Sample (48 files):** 22 movie MKV (x264, every audio kind — AC-3/E-AC-3/DD+ 5.1&7.1/DTS/DTS-ES/DTS-HD MA/FLAC/Atmos), 2× 2160p HEVC+Dolby Vision+HDR+Atmos, 3 movie MP4, 3 TV MKV, F1+UFC web, 4 broadcast TS (incl. Nick/Evermoor controls), 4 BDAV M2TS (AVC + LPCM), 2 `.mpls`, 3 DVD IFO + 1 VOB, 1 m4b, 1 mp3.
+
+---
+
+## Scorecard (true field-diff, created-date artifact removed)
+
+| true_diff | files |
+|--:|---|
+| **0 (perfect)** | `mp4_ac3`, `mkv_dts_d` (38-track!), `dvd_ifo_ntsc/1995/pal`, `ts_ctrl_nick`, `ts_ctrl_evermoor` |
+| 1–2 | Cape Fear **4K HDR/DV** (×2), `mkv_atmos_web`, `mkv_tv_eac3`, `mp4_ac3_c`, `mkv_dts_b/c`, `mkv_tv_eac3_20`, `m2ts_hollywood_short` |
+| 3–8 | most M2TS, `mkv_dtshdma`, `mkv_dts`, `mkv_eac3_51`, `mkv_eac3_51b`, `mkv_ufc_h264`, `audio_mp3`, … |
+| 13–29 | `mkv_ac3_51`, `mkv_eac3_71/71b`, `mkv_dts_e/es`, `mkv_nordic`, `mkv_x264_untagged`, `mp4_ufc_aac`, `mkv_f1_x264`, `mkv_tv_ac3_720`, `mp4_ac3_b` |
+| 38–75 | `dvd_vob_ntsc` (38), `mkv_flac` (70, 56 tracks), `mkv_eac3_71c` (75, 40 tracks) |
+| track-count gaps | `.mpls` (1 vs 202/32 — unimplemented), `ts_ctn_thursdays` (Text 4 vs 5), `m4b` (Menu 1 vs 2 + spurious Text) |
+
+The high scorers are **track-count × per-track-field** multipliers (a sub-heavy 40/56-track file multiplies one missing per-track field into dozens of diffs), not 40 distinct bugs.
+
+---
+
+## Ranked findings
+
+Legend — **Class:** BUG (go wrong/missing) · QUIRK (official questionable, go arguably better) · LONGTAIL (known tuning) · FEATURE (unimplemented). **Conf:** code+data verified / empirical.
+
+### Tier 1 — clear correctness bugs (fix first)
+
+**1. `General.StreamSize` 40–50× too large; `Video.BitRate`/`Video.StreamSize` missing** — *BUG, code-verified, HIGH impact, effort M*
+Files: Iron Man 2, F1, Star Wars IV, Dag 720p (4/22 large MKVs). Audio stream sizes are correct, so this is purely video: when the cluster scan doesn't directly measure video bytes, go emits **neither** `Video.StreamSize` nor `Video.BitRate`, so `General.StreamSize` collapses to ≈ whole file (e.g. **11 688 475 047** vs official **248 645 459**). Iron Man 2 even has the answer — go parsed `BitRate_Nominal=12500000` from x264 settings but never promoted it to `BitRate` or derived StreamSize from it.
+*Fix:* in the Matroska size path (`matroska_scan.go` ~876–1013 + General remainder calc), when direct video bytes are unavailable, derive `Video.StreamSize` as the **remainder** (FileSize − overhead − audio − text) and back-compute `BitRate` — the remainder approach already exists for BDAV; apply it here. Promote `BitRate_Nominal`→`BitRate` when that's all there is.
+
+**2. DTS-HD: `Format="DTS XLL"` should be `"DTS"`** — *BUG, code-verified, MED impact, effort S+M*
+`matroska_scan.go:1277` literally sets `Format = "DTS XLL"`; official keeps `Format="DTS"` and puts the extension in `Format_AdditionalFeatures`. go also emits `"XLL"` where official emits `"ES XCh XLL"` — it never detects the DTS-ES core extension (XCh).
+*Fix:* stop concatenating into `Format` (keep `"DTS"`); build `Format_AdditionalFeatures` from core-extension (XCh/ES) + ExSS (XLL/XBR). The `Format`-string change is trivial; XCh detection is the work.
+
+**3. `Audio.Format_Settings_Endianness="Big"` missing on plain AC-3** — *BUG, code-verified, MED-HIGH impact, effort S*
+The Matroska audio enrichment sets Endianness for E-AC-3 (`matroska_scan.go:1490`) and DTS (`:1393`) but **not plain AC-3** — so every AC-3 MKV track drops it. One-line addition in the AC-3 branch. (E-AC-3 7.1 also drops it, but via bug #5.)
+
+**4. `Video.FrameRate_Num`/`FrameRate_Den` never emitted for Matroska** — *BUG, code-verified, MED impact, effort S*
+`json_fields.go:359` only emits Num/Den for `MPEG-4 | MPEG-TS | BDAV`; **Matroska isn't in the allowlist**, so every CFR MKV is missing them (The Pianist=24, Sopranos=25, F1=50, Dag=25). Add Matroska to the gate. *(Separate value-bug: MP4/DVD NTSC fraction — UFC mp4 `FrameRate_Num=30` vs official `29970`; go didn't represent 29.97 as a fraction. Effort M.)*
+
+### Tier 2 — parity-vs-correctness (needs your call)
+
+**5. DD+ 7.1: go `Format="E-AC-3"` vs official `"AC-3"` + `Dep` — and this drops the AC-3-core fields** — *QUIRK/BUG, code-verified, HIGH impact, effort M-L*
+Highest-leverage item. The Gentlemen / Sinners / Apocalypse Now (all DD+ **7.1**). Official treats these as **AC-3 core + dependent E-AC-3 substream** (`Format="AC-3"`, `Format_AdditionalFeatures="Dep"`), which is *why* official emits `Endianness`, `compr_*`, `dialnorm`, `SamplesPerFrame` on them — they're AC-3-core BSI fields. go labels the track flat `E-AC-3` and therefore **drops all of those** (confirmed: 5.1 E-AC-3 like Oppenheimer is byte-perfect; only the 7.1 "core+substream" case breaks). One root cause explains the Format mismatch *and* ~5 missing fields per file, on the **most common modern release audio**.
+*Decision:* match official (AC-3 + Dep, parse the core) for parity and to recover the BSI fields — **recommended** — vs keep the arguably-more-correct flat `E-AC-3` and just add the missing fields.
+
+**6. `Format_Commercial_IfAny` missing for DTS-ES Discrete & HE-AAC; `Format_AdditionalFeatures` misses `ES XCh`/`SBR`** — *BUG, empirical, MED impact, effort M*
+go's commercial-name machinery works (it nails DTS-HD MA, DD+) but lacks the DTS-ES-Discrete and HE-AAC cases because it under-detects the DTS **XCh** core extension and AAC **SBR** (so it reports `LC` not `LC SBR`, never realizing it's HE-AAC). Shares root with #2.
+
+**7. `Audio.ChannelLayout` ordering + DTS-ES `*_Original` channels** — *BUG, empirical, MED impact, effort M*
+7.1: official `L R C LFE Ls Rs Lb Rb` vs go `C L R Ls Rs Lb Rb LFE` (different convention). DTS-ES: official emits `Channels_Original`/`ChannelLayout_Original`/`ChannelPositions_Original` (matrixed 6.1→5.1) that go omits; conversely go *adds* `ChannelLayout` on some DTS tracks official leaves bare.
+
+**8. `Video.BitRate_Maximum` over-emitted** — *BUG (go-extra), empirical, LOW-MED, effort S*
+Gladiator II, Casablanca, DVD VOB, Network M2TS: go emits a max bitrate official omits for these container/codec combos.
+
+### Tier 3 — long-tail / known tuning
+
+**9. AC-3 `extra.compr_*`/`dynrng_*` stats** — *LONGTAIL, MED impact, effort M-L*
+On **Matroska** (not just the TS windows AGENTS.md tracks), go captures essentially one frame under ParseSpeed=0.5: Forrest Gump `compr_Count=1` vs official **2090**. The TS-side windowing is well-tuned; the MKV-side AC-3 stats sampling is the bigger remaining miss.
+
+**10. `Audio.FrameCount` gating** — *BUG, empirical, LOW-MED* — emitted inconsistently (AAC tracks missing it; some AC-3 commentary tracks emit it where official doesn't). ParseSpeed-dependent gating differs from official in both directions.
+
+**11. `Text.MuxingMode="zlib"` missing** — *BUG, empirical, LOW* — zlib-compressed Matroska subtitle tracks (Oppenheimer) lose the MuxingMode field.
+
+**12. `Text.Duration`/`Text.Language`/`Text.extra.Source` on sub-heavy files** — *mixed, LOW per-file but inflates totals* — Sinners (40 subs) & Silence of the Lambs (56 tracks) drive the two worst scores via one or two per-track fields × many tracks.
+
+**13. `Audio.BitRate` rounding** — *LONGTAIL, LOW* — go rounds AC-3 to clean kbps (160000) vs official exact (159880); cosmetic.
+
+### Structural / unimplemented (bigger pieces)
+
+**14. Blu-ray `.mpls` playlists — effectively unimplemented** — *FEATURE, HIGH for disc workflows, effort XL*
+go emits **1** track; official aggregates the playlist (Network `.mpls`: 202 tracks = 100 Video + 100 Audio + Menu; Hollywood `.mpls`: 32). A real parser needs PlayList/PlayItem/STN_table → resolve referenced clip `.m2ts` → aggregate streams + chapter marks. Single largest structural gap.
+
+**15. MPEG-TS one caption track short** — *BUG, LOW, effort M* — `ts_ctn_thursdays` Text 4 vs 5 (a missing caption service on certain Cartoon Network captures).
+
+**16. M4B chapters** — *BUG, LOW, effort M* — audiobook `.m4b`: Menu 1 vs 2 and a spurious Text track (go doesn't fold the QuickTime text chapter track into Menu the way official does).
+
+---
+
+## "Lacking / ancient" — modernization candidates
+
+In scope (release media), where the original or the port is dated:
+
+- **AV1 — zero support in the port** (no `AV1`/`av01` anywhere in source). This is the one modern codec actively appearing in releases (WEB/anime) that go can't read at all. **Highest-value modern add** (sequence-header/OBU parser). Effort L.
+- **AC-4** and **MPEG-H 3D Audio** — 0 support. Niche today (ATSC 3.0 / some streaming); low priority for this library.
+- **VP9 / Opus / AVIF** — codec-ID-level only; WebM mostly rides the Matroska path. Worth fleshing out Opus (appears in anime/WEB) parsing for bit-exact parity.
+- Out of scope but absent: HEIF/JXL/WebP/Theora/FFV1/ProRes.
+
+Correctness-over-legacy-quirks candidates (where go can be *better* than v23.04, behind a flag if 1:1 matters):
+- `File_Created_Date` on Linux (go already more complete).
+- DD+ → `E-AC-3` labelling (go's flat label is arguably more correct than official's `AC-3`+`Dep`; see #5 for the trade-off).
+
+---
+
+## Recommended order (value ÷ effort)
+
+1. **#3 AC-3 Endianness** (one line) · **#4 MKV FrameRate_Num/Den** (one gate) · **#2 DTS `Format` string** (one line) — three near-free, broadly-applied parity wins.
+2. **#1 Video StreamSize remainder/nominal-promote** — kills the single most visible bug (11.7 GB→248 MB).
+3. **#5 DD+ 7.1 AC-3-core+Dep** — biggest *bundle* (Format + 5 fields) on the most common release audio.
+4. **#6 DTS-ES/HE-AAC detection** (XCh + SBR) → fixes commercial names + additional features together.
+5. Then #7 channel layout, #8 bitrate-max, #9 MKV AC-3 stats, #10–#13 long-tail.
+6. **Separate projects:** `.mpls` parser (#14, XL) and **AV1 support** (modernization, L).
+
+Quick wins #1–#4 alone should move a large fraction of the 22 movie MKVs toward 0–2.
+
+---
+
+## Appendix — code-level root causes (file:line)
+
+Verified by reading the Go source (and, for 8 items, an independent root-cause pass cross-checked against the upstream MediaInfoLib v23.04 C++; the `File_*.cpp` references below are from that pass).
+
+**#1 StreamSize collapse** *(my analysis + 2026-06-19 experiment — deferred to its own PR)*
+- Affects **untagged** MKVs only. Tagged releases (mkvmerge `NUMBER_OF_BYTES`/`BPS` Statistics Tags) get exact per-track sizes with no scan; untagged files (Iron Man 2, F1, SW-IV, Dag) hit `shouldApplyMatroskaClusterStats` (matroska.go:515) which returns false at ParseSpeed<1, so `applyMatroskaStats` (matroska_scan.go:862) never runs → no `Video.StreamSize`/`BitRate`, and `General.StreamSize` (= FileSize − Σtracks, analyze.go:491) collapses to ≈ full file. The video nominal→BitRate promotion (matroska_scan.go:1013) is *also* gated behind that scan, so Iron Man 2 keeps `BitRate_Nominal` but emits no `BitRate`.
+- **Experiment result (rejected approach):** forcing the cluster scan for untagged files is (a) catastrophically slow — **52 s (Iron Man 2), 169 s (F1)** vs official 1.7 s — and (b) **not byte-exact**: go's block-byte sum = 11.685 GB vs official `StreamSize` 11.439 GB. So official does **not** sum raw block bytes.
+- **Real fix:** official derives `Video.StreamSize = FileSize − Σaudio − overhead`, where overhead ≈ 1.99% on both sampled files (248 MB / 147 MB) and is computed *cheaply* (no full scan). `BitRate` = nominal if present (Iron Man 2: 12.5 M, exact) else `StreamSize×8/Duration` (F1: 5362756). Implementing this means replicating MediaInfo's Matroska overhead model (EBML/cluster framing) and feeding video into the existing remainder math (analyze.go:1134–1148 already does this for BDAV). M-effort; needs validation across a wider untagged-MKV set than this audit's 4 files. **Not a quick win — split out.**
+
+**#2 DTS `Format="DTS XLL"`** — `matroska_scan.go:1277/1283` (sets Format to "DTS XLL"/"DTS XBR"); leaks to JSON because `splitAACFormat` (`json_fields.go:575`) only strips an `"AAC "` prefix. ES/XCh lost because `parseDTSCoreFrame` (`matroska_scan.go:2152-2153`) discards the Extension-Audio-Descriptor + Extended-Coding bits; no XCh-sync detection. Same AdditionalFeatures loss in TS path `mpeg_ts.go:2231-2236`. Upstream always `Format="DTS"` (`File_Dts.cpp:715`).
+
+**#3 AC-3 Endianness** — gate `if probe.format == "E-AC-3"` at `matroska_scan.go:1489` excludes plain AC-3. Fix: move `stream.JSON["Format_Settings_Endianness"]="Big"` to the common AC-3/E-AC-3 section (~1467); the DTS path at `:1393` is the correct unconditional pattern.
+
+**#4 FrameRate_Num/Den** — fragmented: `json_fields.go:227` only lifts Num/Den from a text token; fallback `json_fields.go:357` gated to MPEG-4/TS/BDAV (excludes Matroska); `format_rates.go:12` drops integer Num/Den (only emits when den>1); `rationalizeFrameRate` `json_fields.go:498` tolerance too tight + emits 30000/1001 not 29970/1000; DVD hardcode `dvd.go:270`; pulldown gap `mpeg2_video.go:661`. Fix: one central `deriveFrameRateNumDen(rate)` (port of `File__Analyze_Streams.cpp:2266-2298`) for every video stream.
+
+**#5 DD+ 7.1 `Dep`** — `matroska_codec.go:19-20` hard-maps `A_EAC3→"E-AC-3"`; `ac3.go:503/559` reads `strmtyp` but never records dependent-substream presence; `eac3_joc.go:76-86` reads `numDepSub` then discards it; emission slot exists (`json_field_order.go:145`). Fix: record `strmtyp==1` (dependent substream) through the probe, emit `Format_AdditionalFeatures="Dep"` and match official's `Format="AC-3"`; this also restores the AC-3-core BSI fields.
+
+**#6 DTS-ES / HE-AAC commercial** — emission machinery works (`json_fields.go:187-188`); signal detected but not surfaced: AAC SBR at `matroska.go:2991` only feeds `Format_Settings_SBR`; DTS ES/XCh discarded in `parseDTSCoreFrame`. Add "DTS-ES Discrete" / "HE-AAC" commercial-name cases.
+
+**#7 ChannelLayout** — count-based lookup `channel_layout.go:18-21` (`8→"C L R Ls Rs Lb Rb LFE"`) instead of bitstream arrangement; E-AC-3 7.1 reaches the count fallback because `ac3ChannelLayout` (`ac3.go:1204-1242`) caps at 5.1 and `chan_loc` (`eac3_joc.go:81`) is read only for the JOC bed mask. Don't touch the shared count map; build the real layout from acmod+chan_loc. Effort L.
+
+**#11 Text MuxingMode "zlib"** — `matroska.go:1298` only emits MuxingMode for algo 3 (Header stripping); Text tracks get `Compression_Mode="Lossless"` (`matroska.go:1713-1716`) instead of `MuxingMode="zlib"`; `parseMatroskaContentCompression` (`:1828`) returns false when no explicit algo child (drops implicit zlib default). Note `matroska_test.go:156-181` currently asserts the buggy behavior — update it. Effort S.
+
+**Empirical-only (root-cause agent rate-limited, classified from output data):** #8 BitRate_Maximum over-emit, #9 MKV AC-3 stats window, #10 FrameCount gating, #12 Text Source/Duration, #14 `.mpls`, #15 TS caption track, #16 m4b chapters. Happy to deep-dive any on request.

--- a/internal/mediainfo/json_fields.go
+++ b/internal/mediainfo/json_fields.go
@@ -355,8 +355,10 @@ func buildJSONComputedFields(kind StreamKind, fields []jsonKV, containerFormat s
 			out = append(out, jsonKV{Key: "FrameCount", Val: strconv.Itoa(frameCount)})
 		}
 		// MediaInfo emits FrameRate_Num/Den for some containers even when the displayed frame rate
-		// field lacks a "(num/den)" hint (e.g. BDAV and MPEG-TS).
-		if (containerFormat == "MPEG-4" || containerFormat == "MPEG-TS" || containerFormat == "BDAV") &&
+		// field lacks a "(num/den)" hint (e.g. BDAV, MPEG-TS, and Matroska at integer rates).
+		// The guard reads the already-emitted JSON, so 23.976 (which gets Num/Den from the text
+		// token path) is not double-emitted here.
+		if (containerFormat == "MPEG-4" || containerFormat == "MPEG-TS" || containerFormat == "BDAV" || containerFormat == "Matroska") &&
 			jsonFieldValue(fields, "FrameRate_Num") == "" && jsonFieldValue(fields, "FrameRate_Den") == "" {
 			num, den := rationalizeFrameRate(frameRate)
 			if num > 0 && den > 0 {

--- a/internal/mediainfo/matroska_parity_test.go
+++ b/internal/mediainfo/matroska_parity_test.go
@@ -24,3 +24,32 @@ func TestApplyMatroskaAudioProbes_Endianness(t *testing.T) {
 		})
 	}
 }
+
+// Official MediaInfo emits Video.FrameRate_Num/Den for Matroska CFR video even
+// when the displayed rate is an integer (no "(num/den)" hint), which the
+// text-token path can't recover. Parity audit (2026-06-19): 5 integer-rate MKVs.
+func TestBuildJSONComputedFields_MatroskaFrameRateNumDen(t *testing.T) {
+	t.Run("integer rate emits Num/Den", func(t *testing.T) {
+		fields := []jsonKV{
+			{Key: "Duration", Val: "1383.040"},
+			{Key: "FrameRate", Val: "25.000"},
+		}
+		out := buildJSONComputedFields(StreamVideo, fields, "Matroska")
+		if num, den := jsonFieldValue(out, "FrameRate_Num"), jsonFieldValue(out, "FrameRate_Den"); num != "25" || den != "1" {
+			t.Fatalf("got Num=%q Den=%q, want 25/1", num, den)
+		}
+	})
+	// 23.976 already carries Num/Den from the text-token path; must not re-emit.
+	t.Run("ratio already present is not duplicated", func(t *testing.T) {
+		fields := []jsonKV{
+			{Key: "Duration", Val: "100"},
+			{Key: "FrameRate", Val: "23.976"},
+			{Key: "FrameRate_Num", Val: "24000"},
+			{Key: "FrameRate_Den", Val: "1001"},
+		}
+		out := buildJSONComputedFields(StreamVideo, fields, "Matroska")
+		if got := jsonFieldValue(out, "FrameRate_Num"); got != "" {
+			t.Fatalf("re-emitted FrameRate_Num=%q, want none", got)
+		}
+	})
+}

--- a/internal/mediainfo/matroska_parity_test.go
+++ b/internal/mediainfo/matroska_parity_test.go
@@ -1,0 +1,26 @@
+package mediainfo
+
+import "testing"
+
+// audioStreamWithID builds a minimal Matroska audio Stream carrying the given
+// container track ID (so streamTrackNumber can match it to a probe).
+func audioStreamWithID(id string) Stream {
+	return Stream{Kind: StreamAudio, Fields: []Field{{Name: "ID", Value: id}}}
+}
+
+// Official MediaInfo emits Format_Settings_Endianness="Big" for every AC-3 and
+// E-AC-3 track, not just E-AC-3. Regression guard for the parity audit (2026-06-19).
+func TestApplyMatroskaAudioProbes_Endianness(t *testing.T) {
+	for _, format := range []string{"AC-3", "E-AC-3"} {
+		t.Run(format, func(t *testing.T) {
+			info := &MatroskaInfo{Tracks: []Stream{audioStreamWithID("1")}}
+			probes := map[uint64]*matroskaAudioProbe{
+				1: {format: format, ok: true},
+			}
+			applyMatroskaAudioProbes(info, probes)
+			if got := info.Tracks[0].JSON["Format_Settings_Endianness"]; got != "Big" {
+				t.Fatalf("%s Format_Settings_Endianness = %q, want %q", format, got, "Big")
+			}
+		})
+	}
+}

--- a/internal/mediainfo/matroska_parity_test.go
+++ b/internal/mediainfo/matroska_parity_test.go
@@ -53,3 +53,28 @@ func TestBuildJSONComputedFields_MatroskaFrameRateNumDen(t *testing.T) {
 		}
 	})
 }
+
+// Official MediaInfo keeps Audio.Format="DTS" for DTS-HD and carries the
+// extension in Format_AdditionalFeatures; go was folding it into Format
+// ("DTS XLL"). Parity audit (2026-06-19). (ES/XCh detection is a separate fix.)
+func TestApplyMatroskaAudioProbes_DTSHDFormatNotMangled(t *testing.T) {
+	info := &MatroskaInfo{Tracks: []Stream{{Kind: StreamAudio, Fields: []Field{
+		{Name: "ID", Value: "1"},
+		{Name: "Format", Value: "DTS"},
+		{Name: "Format/Info", Value: "Digital Theater Systems"},
+	}}}}
+	probes := map[uint64]*matroskaAudioProbe{
+		1: {format: "DTS", ok: true, dts: dtsInfo{hd: true, hdXLL: true}},
+	}
+	applyMatroskaAudioProbes(info, probes)
+	got := info.Tracks[0]
+	if f := findField(got.Fields, "Format"); f != "DTS" {
+		t.Fatalf("Format = %q, want \"DTS\" (extension must not be folded into Format)", f)
+	}
+	if got.JSON["Format_AdditionalFeatures"] != "XLL" {
+		t.Fatalf("Format_AdditionalFeatures = %q, want \"XLL\"", got.JSON["Format_AdditionalFeatures"])
+	}
+	if got.JSON["Format_Commercial_IfAny"] != "DTS-HD Master Audio" {
+		t.Fatalf("Format_Commercial_IfAny = %q, want \"DTS-HD Master Audio\"", got.JSON["Format_Commercial_IfAny"])
+	}
+}

--- a/internal/mediainfo/matroska_scan.go
+++ b/internal/mediainfo/matroska_scan.go
@@ -1273,14 +1273,13 @@ func applyMatroskaAudioProbes(info *MatroskaInfo, probes map[uint64]*matroskaAud
 					stream.JSON = map[string]string{}
 				}
 				if dts.hdXLL {
-					// DTS-HD Master Audio (XLL): lossless.
-					stream.Fields = setFieldValue(stream.Fields, "Format", "DTS XLL")
+					// DTS-HD Master Audio (XLL): lossless. Official keeps Format="DTS"
+					// and carries the extension in Format_AdditionalFeatures only.
 					stream.Fields = insertFieldAfter(stream.Fields, Field{Name: "Commercial name", Value: "DTS-HD Master Audio"}, "Format/Info")
 					stream.JSON["Format_AdditionalFeatures"] = "XLL"
 					stream.JSON["Format_Commercial_IfAny"] = "DTS-HD Master Audio"
 				} else if dts.hdXBR {
-					// DTS-HD High Resolution Audio (XBR): lossy VBR.
-					stream.Fields = setFieldValue(stream.Fields, "Format", "DTS XBR")
+					// DTS-HD High Resolution Audio (XBR): lossy VBR. Format stays "DTS".
 					stream.Fields = insertFieldAfter(stream.Fields, Field{Name: "Commercial name", Value: "DTS-HD High Resolution Audio"}, "Format/Info")
 					stream.JSON["Format_AdditionalFeatures"] = "XBR"
 					stream.JSON["Format_Commercial_IfAny"] = "DTS-HD High Resolution Audio"

--- a/internal/mediainfo/matroska_scan.go
+++ b/internal/mediainfo/matroska_scan.go
@@ -1486,9 +1486,9 @@ func applyMatroskaAudioProbes(info *MatroskaInfo, probes map[uint64]*matroskaAud
 				stream.JSON["SamplingCount"] = strconv.FormatInt(samplingCount, 10)
 			}
 		}
-		if probe.format == "E-AC-3" {
-			stream.JSON["Format_Settings_Endianness"] = "Big"
-		}
+		// Official MediaInfo reports AC-3 and E-AC-3 bitstreams as big-endian, not
+		// just E-AC-3 (the DTS branch above already sets this unconditionally).
+		stream.JSON["Format_Settings_Endianness"] = "Big"
 		if code := ac3ServiceKindCode(ac3.bsmod); code != "" {
 			stream.JSON["ServiceKind"] = code
 		}


### PR DESCRIPTION
Three small Matroska JSON parity fixes found by a broad audit against MediaInfoLib v23.04 (`docs/parity-audit-2026-06-19.md`): emit `Format_Settings_Endianness=Big` for plain AC-3 (it was only set for E-AC-3/DTS), emit `Video.FrameRate_Num/Den` for integer-rate MKVs (24/25/30/50 — Matroska was excluded from the derivation gate; 23.976 already worked and isn't double-emitted), and stop folding the DTS-HD extension into `Audio.Format` (`DTS XLL` → `DTS`, extension stays in `Format_AdditionalFeatures`). Each is test-driven.

Verified on ~22 real release MKVs (official vs go, `--Output=JSON --Language=raw --ParseSpeed=0.5`): **13 files moved closer to byte-parity, one to exact (0), zero regressions, controls unchanged.** The audit doc also records the remaining backlog; the largest item — `General.StreamSize` collapse on untagged MKVs — is deliberately left for its own PR, since an experiment showed that forcing a full cluster scan is both far too slow (52–169 s/file) and not byte-exact; it needs MediaInfo's cheap overhead model instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of audio codec information detection for AC-3, E-AC-3, and DTS-HD formats
  * Fixed video frame rate calculation for Matroska container files
  * Enhanced compatibility with MediaInfoLib for media file metadata extraction

* **Documentation**
  * Added comprehensive parity audit report documenting accuracy improvements

* **Tests**
  * Expanded test coverage for audio and video metadata handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->