### PR TITLE
docs: state that beating mediainfo is the goal, parity is the method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,10 @@
 Owner: soup
 
 ## Scope
-- Goal: 1:1 feature parity with MediaInfo CLI
+- Goal: be better than MediaInfo CLI. Parity is the test method, not the target.
+  - Diffing against official MediaInfo is how we find our bugs, because it is usually right.
+  - Where official is wrong or gives up, fixing it is the point. "MediaInfoLib does it this way" is not a reason to close an improvement.
+  - Prove any deliberate difference with a real file before shipping it, and say why in the commit.
 - Pure Go implementation, no CGO
 - Cross-platform
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
-## Parity (1:1 MediaInfo CLI)
-- Goal: 1:1 MediaInfo CLI parity (fields + values + ordering) across text/JSON/XML/CSV
+## Parity (vs MediaInfo CLI)
+- Match MediaInfo CLI (fields + values + ordering) across text/JSON/XML/CSV, until we have reason to be better. See `AGENTS.md` for the goal: parity is the test method, not the target.
 - Expand format coverage + field parity across CLI outputs
 - Samples: generated fixtures in `samples/` (see `samples/README.md` + `samples/generate.sh`)
 - Real-world spot checks (2026-02-09): JSON 1:1 vs official at `--ParseSpeed=0.5` for:


### PR DESCRIPTION
The scope line read "1:1 feature parity with MediaInfo CLI", which lands as a ceiling rather than a test method. During triage it argued for closing real improvements on the grounds that MediaInfoLib behaves the same way — including cases where official gives up on a valid file (#24) or silently drops data (#30).

Rewords it to say what parity is actually for: diffing against official is how we find our bugs, because official is usually right. Where it is not, fixing it is the point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance to prioritize improving on MediaInfo CLI behavior while continuing to use parity testing.
  * Added documentation requirements for intentional differences, including validation with a real file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->