### PR TITLE
feat: add AV1 format info to Matroska and MP4 containers

### DIFF
--- a/internal/mediainfo/matroska_codec.go
+++ b/internal/mediainfo/matroska_codec.go
@@ -67,6 +67,8 @@ func mapMatroskaCodecID(codecID string, trackType uint64) (StreamKind, string) {
 
 func mapMatroskaFormatInfo(format string) string {
 	switch format {
+	case "AV1":
+		return "AOMedia Video 1"
 	case "AVC":
 		return "Advanced Video Codec"
 	case "HEVC":

--- a/internal/mediainfo/matroska_codec_test.go
+++ b/internal/mediainfo/matroska_codec_test.go
@@ -11,11 +11,19 @@ func TestMapMatroskaCodecID(t *testing.T) {
 	}{
 		{codecID: "A_OPUS", trackType: 2, kind: StreamAudio, format: "Opus"},
 		{codecID: "S_DVBSUB", trackType: 17, kind: StreamText, format: "DVB Subtitle"},
+		{codecID: "V_AV1", trackType: 1, kind: StreamVideo, format: "AV1"},
 	}
 	for _, test := range tests {
 		kind, format := mapMatroskaCodecID(test.codecID, test.trackType)
 		if kind != test.kind || format != test.format {
 			t.Fatalf("mapMatroskaCodecID(%q) = %v, %q; want %v, %q", test.codecID, kind, format, test.kind, test.format)
 		}
+	}
+}
+
+func TestMapMatroskaFormatInfoAV1(t *testing.T) {
+	got := mapMatroskaFormatInfo("AV1")
+	if got != "AOMedia Video 1" {
+		t.Fatalf("mapMatroskaFormatInfo(AV1) = %q; want %q", got, "AOMedia Video 1")
 	}
 }

--- a/internal/mediainfo/mp4_codec.go
+++ b/internal/mediainfo/mp4_codec.go
@@ -1217,8 +1217,7 @@ func mapVideoFormatInfo(sampleType string) string {
 
 func mapVideoCodecIDInfo(sampleType string) string {
 	switch sampleType {
-	case "av01":
-		return "AOMedia Video 1"
+	// av01: info column in MediaInfoLib CodecID_Video_Mpeg4.csv is empty.
 	case "avc1", "avc3":
 		return "Advanced Video Coding"
 	case "hvc1", "hev1":

--- a/internal/mediainfo/mp4_codec.go
+++ b/internal/mediainfo/mp4_codec.go
@@ -156,6 +156,8 @@ func parseStsdForSample(buf []byte) (SampleInfo, bool) {
 // codec format.
 func mapMP4SampleEntry(sample string) string {
 	switch sample {
+	case "av01":
+		return "AV1"
 	case "avc1", "avc3":
 		return "AVC"
 	case "hvc1", "hev1":
@@ -190,7 +192,7 @@ func mapMP4SampleEntry(sample string) string {
 // isVideoSampleEntry reports whether sample is a supported MP4 video entry.
 func isVideoSampleEntry(sample string) bool {
 	switch sample {
-	case "avc1", "avc3", "hvc1", "hev1", "mp4v", "vp09":
+	case "av01", "avc1", "avc3", "hvc1", "hev1", "mp4v", "vp09":
 		return true
 	default:
 		return false
@@ -1200,6 +1202,8 @@ func parseBtrt(entry []byte, start int) (uint32, uint32, uint32, bool) {
 
 func mapVideoFormatInfo(sampleType string) string {
 	switch sampleType {
+	case "av01":
+		return "AOMedia Video 1"
 	case "avc1", "avc3":
 		return "Advanced Video Codec"
 	case "hvc1", "hev1":
@@ -1213,6 +1217,8 @@ func mapVideoFormatInfo(sampleType string) string {
 
 func mapVideoCodecIDInfo(sampleType string) string {
 	switch sampleType {
+	case "av01":
+		return "AOMedia Video 1"
 	case "avc1", "avc3":
 		return "Advanced Video Coding"
 	case "hvc1", "hev1":

--- a/internal/mediainfo/mp4_codec_test.go
+++ b/internal/mediainfo/mp4_codec_test.go
@@ -82,17 +82,20 @@ func TestParseMP4CodecFromStsd(t *testing.T) {
 	}
 }
 
-func buildTrackWithStsd(handler, sample string) []byte {
+func buildTrackWithStsd(handler, sample string, childBoxes ...[]byte) []byte {
 	var stsd bytes.Buffer
 	stsd.Write([]byte{0x00, 0x00, 0x00, 0x00})
 	if err := binary.Write(&stsd, binary.BigEndian, uint32(1)); err != nil {
 		panic(err)
 	}
 	entry := make([]byte, 86)
-	binary.BigEndian.PutUint32(entry[0:4], uint32(len(entry)))
 	copy(entry[4:8], []byte(sample))
 	binary.BigEndian.PutUint16(entry[32:34], 1920)
 	binary.BigEndian.PutUint16(entry[34:36], 1080)
+	for _, child := range childBoxes {
+		entry = append(entry, child...)
+	}
+	binary.BigEndian.PutUint32(entry[0:4], uint32(len(entry)))
 	stsd.Write(entry)
 
 	var stbl bytes.Buffer
@@ -138,7 +141,9 @@ func TestParseMP4CodecAV1FromStsd(t *testing.T) {
 	binary.BigEndian.PutUint32(mvhd[12:16], 1000)
 	binary.BigEndian.PutUint32(mvhd[16:20], 10000)
 
-	trak := buildTrackWithStsd("vide", "av01")
+	var av1CBuf bytes.Buffer
+	writeMP4Box(&av1CBuf, "av1C", []byte{0x81, 0x05, 0x0C, 0x00})
+	trak := buildTrackWithStsd("vide", "av01", av1CBuf.Bytes())
 	var moov bytes.Buffer
 	writeMP4Box(&moov, "mvhd", mvhd)
 	writeMP4Box(&moov, "trak", trak)

--- a/internal/mediainfo/mp4_codec_test.go
+++ b/internal/mediainfo/mp4_codec_test.go
@@ -184,7 +184,7 @@ func TestParseMP4CodecAV1FromStsd(t *testing.T) {
 	if v := findField(info.Tracks[0].Fields, "Format/Info"); v != "AOMedia Video 1" {
 		t.Fatalf("Format/Info=%q, want AOMedia Video 1", v)
 	}
-	if v := findField(info.Tracks[0].Fields, "Codec ID/Info"); v != "AOMedia Video 1" {
-		t.Fatalf("Codec ID/Info=%q, want AOMedia Video 1", v)
+	if v := findField(info.Tracks[0].Fields, "Codec ID/Info"); v != "" {
+		t.Fatalf("Codec ID/Info=%q, want absent", v)
 	}
 }

--- a/internal/mediainfo/mp4_codec_test.go
+++ b/internal/mediainfo/mp4_codec_test.go
@@ -129,3 +129,57 @@ func buildSttsBox() []byte {
 	binary.BigEndian.PutUint32(buf[12:16], 3000)
 	return buf
 }
+
+func TestParseMP4CodecAV1FromStsd(t *testing.T) {
+	var buf bytes.Buffer
+	writeMP4Box(&buf, "ftyp", []byte{'i', 's', 'o', 'm'})
+	mvhd := make([]byte, 20)
+	mvhd[0] = 0
+	binary.BigEndian.PutUint32(mvhd[12:16], 1000)
+	binary.BigEndian.PutUint32(mvhd[16:20], 10000)
+
+	trak := buildTrackWithStsd("vide", "av01")
+	var moov bytes.Buffer
+	writeMP4Box(&moov, "mvhd", mvhd)
+	writeMP4Box(&moov, "trak", trak)
+	writeMP4Box(&buf, "moov", moov.Bytes())
+
+	file, err := os.CreateTemp(t.TempDir(), "sample-av1-*.mp4")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	if _, err := file.Write(buf.Bytes()); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	stat, err := os.Stat(file.Name())
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	f, err := os.Open(file.Name())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	info, ok := ParseMP4(f, stat.Size())
+	if !ok {
+		t.Fatalf("expected mp4 info")
+	}
+	if len(info.Tracks) != 1 {
+		t.Fatalf("expected 1 track, got %d", len(info.Tracks))
+	}
+	if info.Tracks[0].Format != "AV1" {
+		t.Fatalf("format=%q, want AV1", info.Tracks[0].Format)
+	}
+	if v := findField(info.Tracks[0].Fields, "Format/Info"); v != "AOMedia Video 1" {
+		t.Fatalf("Format/Info=%q, want AOMedia Video 1", v)
+	}
+	if v := findField(info.Tracks[0].Fields, "Codec ID/Info"); v != "AOMedia Video 1" {
+		t.Fatalf("Codec ID/Info=%q, want AOMedia Video 1", v)
+	}
+}


### PR DESCRIPTION
Adds AV1 (AOMedia Video 1) Format/Info recognition to both the Matroska and MP4 container parsers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AV1 video codec recognition for Matroska and MP4 media files.
  * AV1 files now display accurate format and codec metadata, including “AOMedia Video 1.”
  * MP4 AV1 media is parsed correctly, with unsupported codec ID details omitted when unavailable.

* **Tests**
  * Added coverage verifying AV1 detection and metadata parsing across supported container formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->